### PR TITLE
Update guava dependency (CVE-2018-10237)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,10 +17,9 @@
   <dependencies>
 
       <dependency>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-          <version>14.0.1</version>
-      </dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>[24.1.1,)</version>
       <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>


### PR DESCRIPTION
Upgrade com.google.guava:guava to version 24.1.1 to resolve Guava vulneratbility (CVE-2018-10237)